### PR TITLE
Fix: Display PromptBuilder on the main page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,14 @@
 import { Header } from "@/components/header"
+import { PromptBuilder } from "@/components/prompt-builder"
 
 export default function Home() {
   return (
     <div className="min-h-screen flex flex-col">
       <Header />
-      <main className="flex-1 container mx-auto p-4">{/* rest of code here */}</main>
+      <main className="flex-1 container mx-auto p-4">
+        <PromptBuilder />
+        {/* rest of code here */}
+      </main>
     </div>
   )
 }


### PR DESCRIPTION
The PromptBuilder component was not visible on the main page because it was not being imported or rendered.

This commit imports and renders the PromptBuilder component in `app/page.tsx` to make it visible.